### PR TITLE
Update FactionCommands.php

### DIFF
--- a/src/FactionsPro/FactionCommands.php
+++ b/src/FactionsPro/FactionCommands.php
@@ -35,7 +35,7 @@ class FactionCommands {
                     $sender->sendMessage($this->plugin->formatMessage("Please use /f help for a list of commands"));
                     return true;
                 }
-                if (count($args == 2)) {
+                if (count($args) == 2) {
 
                     ///////////////////////////////// WAR /////////////////////////////////
 
@@ -177,7 +177,7 @@ class FactionCommands {
                             $sender->sendMessage($this->plugin->formatMessage("Player not online"));
                             return true;
                         }
-                        if ($this->plugin->isInFaction($invited) == true) {
+                        if ($this->plugin->isInFaction($invited->getName()) == true) {
                             $sender->sendMessage($this->plugin->formatMessage("Player is currently in a faction"));
                             return true;
                         }


### PR DESCRIPTION
$invited is an instance of Player, but the function isInFaction() works with the name of the player (string) instead of the player object (Player) so it is $invited->getName(). 

By the way, wasn't I the one who created the modded versions and wasn't Primus the one who added /f map and even /f war? Why are you completely taking credit for something that isn't yours and publish it on poggit? ... You know that, despite the code of this plugin being pretty bad, we took from our time to add these features and you just straight copy-paste it without adding credits? I would understand if you didn't delete our names from /f about and submitted the plugin but... Should have at least put our names back in /f about or should have asked for permission...

Also remove all getNametag / setNametag / updateNametag methods/calls. PureChat is supposed to take care of that, not the FactionsPro plugin. This is also the reason why the nametags of the players that play in mcpe servers are often different because both PureChat and FactionsPro set nametags and this is where the confusion comes from. 

Btw you are using 1.7.6. All the bugs you are going to encounter have already been fixed in 1.7.9 (the original versions)