### PR TITLE
Fixed undefined problem getPlayerByName()

### DIFF
--- a/src/FactionsPro/FactionCommands.php
+++ b/src/FactionsPro/FactionCommands.php
@@ -63,7 +63,7 @@ class FactionCommands {
                                 if ($r == $fac) {
                                     $x = mt_rand(0, $this->plugin->getNumberOfPlayers($fac) - 1);
                                     $tper = $this->plugin->war_players[$f][$x];
-                                    $sender->teleport($this->plugin->getServer()->getPlayerByName($tper));
+                                    $sender->teleport($this->plugin->getServer()->getPlayer($tper));
                                     return true;
                                 }
                                 if ($f == $fac) {


### PR DESCRIPTION
getPlayerByName() is no longer a thing with Pocketmine. I've tested this before, and it came up with undefined errors. This seem to fix it. This was either a typo, or an older way of getting a player's name.